### PR TITLE
Return typeof Schema from #convert

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,9 +21,14 @@ internals.root = function (mongoose, options) {
     };
 };
 
-internals.convert = function (joiSchema) {
-    var schemaDef = internals._convert(joiSchema)
-    return new internals.mongoose.Schema(schemaDef);
+internals.convert = function (joiSchema, opts) {
+    
+    var schemaDef = internals._convert(joiSchema);
+    var schema = new internals.mongoose.Schema(schemaDef, opts);
+    
+    schema._joiSchema = schemaDef;
+    
+    return schema;
 }
 
 internals._convert = function (joiObject) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 var Assert = require('assert');
 var Hoek = require('hoek');
 var Joi = require('joi');
+var Schema = require('mongoose').Schema
 var Mongoose;
 
 var internals = {
@@ -20,7 +21,12 @@ internals.root = function (mongoose, options) {
     };
 };
 
-internals.convert = function (joiObject) {
+internals.convert = function (joiSchema) {
+    var schemaDef = internals._convert(joiSchema)
+    return new internals.mongoose.Schema(schemaDef);
+}
+
+internals._convert = function (joiObject) {
 
     if (joiObject === undefined) {
         throw new Error('Ensure the value you\'re trying to convert exists!');
@@ -80,7 +86,7 @@ internals.convert = function (joiObject) {
     if (joiObject._type === 'object') {
         joiObject._inner.children.forEach(function (child) {
 
-            output[child.key] = internals.convert(child.schema);
+            output[child.key] = internals._convert(child.schema);
 
             if (internals.isObjectId(child.schema)) {
                 child.schema._isObjectId = true;
@@ -173,7 +179,7 @@ internals.typeDeterminer = function (joiObject) {
             return type;
         }
 
-        type.push(internals.convert(joiObject._inner.items[0]));
+        type.push(internals._convert(joiObject._inner.items[0]));
         return type;
     }
 


### PR DESCRIPTION
Hello, 

I love the concept, but I need to define additional logic on my Mongoose schemas apart from what Joigoose returns. This of course can be done by writing the additional line like so.

```
var MySchema = joigoose.convert(MySchemaDef)
MySchema = new Schema(MySchema, opts);

MySchema.plugin(...)
        .virtual(function(...) {})
```

However, this addition removed the extra line of boilerplate by returning proper mongoose Schemas.

```
var MySchema = joigoose.convert(MySchemaDef)
                 .plugin(...)
                 .virtual(function(...) {})
```

Let me know what you think. I renamed `internals.convert` to `_convert`, but we could probably expose another method too.
