### PR TITLE
allow joigoose to ignore objects with specific key

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -50,6 +50,10 @@ internals.convert = function (joiObject) {
             if (toClass.call(joiObject._meta[i]) !== '[object Object]') {
                 continue;
             }
+            if (joiObject._meta[i].joigooseIgnore) {
+              // if we've got .meta({joigooseIgnore: true, someKey: 'someValue'}) of a joi object, ignore that object
+              continue;
+            }
 
             for (var key in joiObject._meta[i]) {
                 // Check for _objectId

--- a/test/index.js
+++ b/test/index.js
@@ -143,6 +143,38 @@ describe('Joigoose converter', function() {
         return done();
     });
 
+    it('should not convert a meta field when an ignore is passed in Joi meta object', function (done) {
+
+        const output = Joigoose.convert(O({
+            m_id: S().meta({ className: 'OtherLibraryInformation', joigooseIgnore: true })
+        }));
+
+        expect(output).to.exist();
+        expect(output.m_id).to.exist();
+        expect(output.m_id.className).not.to.exist();
+        expect(output.m_id.type).to.exist();
+        expect(output.m_id.type).to.equal(String);
+        expect(output.m_id.validate).to.exist();
+
+        return done();
+    });
+
+    it('should convert a meta field when an ignore is not passed in Joi meta object', function (done) {
+
+      const output = Joigoose.convert(O({
+          m_id: S().meta({ className: 'OtherLibraryInformation' })
+      }));
+
+      expect(output).to.exist();
+      expect(output.m_id).to.exist();
+      expect(output.m_id.className).to.exist();
+      expect(output.m_id.type).to.exist();
+      expect(output.m_id.type).to.equal(String);
+      expect(output.m_id.validate).to.exist();
+
+      return done();
+    });
+
     it('should convert a Joi object with an ObjectId and reference to a Mongoose schema', function (done) {
 
         const output = Joigoose.convert(O({


### PR DESCRIPTION
I'd like to use joigoose with another library, but without mongoose getting upset about values in the .meta() field this would solve #12 , probably