### PR TITLE
Fix for array of non-strings and non-objects throwing an error on conversion

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -188,7 +188,7 @@ internals.typeDeterminer = (joiObject) => {
       schemaOptions = Object.assign({}, internals.subdocumentOptions, schemaOptions);
     }
 
-    if (internals.typeDeterminer(joiObject._inner.items[0]) === String) {
+    if (internals.typeDeterminer(joiObject._inner.items[0]) !== Object && internals.typeDeterminer(joiObject._inner.items[0]) !== Array) {
       type.push(internals.convert(joiObject._inner.items[0]));
     } else {
       type.push(new internals.mongoose.Schema(internals.convert(joiObject._inner.items[0]), schemaOptions));

--- a/test/index.js
+++ b/test/index.js
@@ -104,7 +104,7 @@ describe('Joigoose converter', () => {
     expect(output.name.validate).to.exist();
   });
 
-  it('should convert a Joi array with strings to a Mongoose schema', () => {
+  it('should convert a Joi array with object of strings to a Mongoose schema', () => {
 
     const output = Joigoose.convert(A().items({ foo: S() }));
     expect(output).to.exist();
@@ -115,6 +115,46 @@ describe('Joigoose converter', () => {
     expect(output.type[0].paths.foo).to.exist();
     expect(output.type[0].paths.foo.instance).to.equal('String');
     expect(output.type[0].paths.foo.options.validate).to.exist();
+  });
+
+  it('should convert a Joi array with strings to a Mongoose schema', () => {
+
+    const output = Joigoose.convert(A().items(S()));
+    expect(output).to.exist();
+    expect(output.type).to.exist();
+    expect(output.type).to.be.an.array();
+    expect(output.type.length).to.equal(1);
+    expect(output.type[0].type).to.equal(String);
+  });
+
+  it('should convert a Joi array with numbers to a Mongoose schema', () => {
+
+    const output = Joigoose.convert(A().items(N()));
+    expect(output).to.exist();
+    expect(output.type).to.exist();
+    expect(output.type).to.be.an.array();
+    expect(output.type.length).to.equal(1);
+    expect(output.type[0].type).to.equal(Number);
+  });
+
+  it('should convert a Joi array with dates to a Mongoose schema', () => {
+
+    const output = Joigoose.convert(A().items(D()));
+    expect(output).to.exist();
+    expect(output.type).to.exist();
+    expect(output.type).to.be.an.array();
+    expect(output.type.length).to.equal(1);
+    expect(output.type[0].type).to.equal(Date);
+  });
+
+  it('should convert a Joi array with booleans to a Mongoose schema', () => {
+
+    const output = Joigoose.convert(A().items(B()));
+    expect(output).to.exist();
+    expect(output.type).to.exist();
+    expect(output.type).to.be.an.array();
+    expect(output.type.length).to.equal(1);
+    expect(output.type[0].type).to.equal(Boolean);
   });
 
   it('should convert a Joi object with a number to a Mongoose schema', () => {


### PR DESCRIPTION
Fixes #21 as we now treat anything that isn't an object or array with its own type validation