### PR TITLE
Custom conversion option typeKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ const Joigoose = require("joigoose")(Mongoose, { convert: false });
 const Mongoose = require("mongoose");
 const Joigoose = require("joigoose")(Mongoose, null, {
   _id: false,
-  timestamps: false
+  timestamps: false,
 });
 ```
 
@@ -55,28 +55,46 @@ Ideally, Joi schemas shouldn't have to contain Mongoose specific types, such as 
 var joiUserSchema = Joi.object({
   name: Joi.object({
     first: Joi.string().required(),
-    last: Joi.string().required()
+    last: Joi.string().required(),
   }),
   email: Joi.string()
     .email()
     .required(),
   bestFriend: Joi.string().meta({
-    _mongoose: { type: "ObjectId", ref: "User" }
+    _mongoose: { type: "ObjectId", ref: "User" },
   }),
   metaInfo: Joi.any(),
   addresses: Joi.array()
     .items({
       line1: Joi.string().required(),
-      line2: Joi.string()
+      line2: Joi.string(),
     })
-    .meta({ _mongoose: { _id: false, timestamps: true }})
+    .meta({ _mongoose: { _id: false, timestamps: true } }),
 });
 ```
 
 ### 3. Convert your Joi schema to a Mongoose-style schema
 
 ```javascript
-var mongooseUserSchema = new Mongoose.Schema(Joigoose.convert(joiUserSchema));
+var mongooseUserSchema = new Mongoose.Schema(
+  Joigoose.convert(joiUserSchema, options)
+);
+```
+
+#### Conversion options
+
+Options can be passed to the convert method as an object. Valid options are described below.
+
+| Key     | Type   | Default | Description                                                                                                                 |
+| ------- | ------ | ------- | --------------------------------------------------------------------------------------------------------------------------- |
+| typeKey | String | "type"  | The name of the key used for [specifying the type](https://mongoosejs.com/docs/guide.html#typeKey) in the generated schema. |
+
+##### Example:
+
+```javascript
+{
+  typeKey: '$type',
+}
 ```
 
 ### 4. Create your model
@@ -91,12 +109,12 @@ User = Mongoose.model("User", mongooseUserSchema);
 var aGoodUser = new User({
   name: {
     first: "Barry",
-    last: "White"
+    last: "White",
   },
   email: "barry@white.com",
   metaInfo: {
-    hobbies: ["cycling", "dancing", "listening to Shpongle"]
-  }
+    hobbies: ["cycling", "dancing", "listening to Shpongle"],
+  },
 });
 
 aGoodUser.save(function(err, result) {
@@ -106,9 +124,9 @@ aGoodUser.save(function(err, result) {
 var aBadUser = new User({
   name: {
     first: "Barry",
-    last: "White"
+    last: "White",
   },
-  email: "Im not an email address!"
+  email: "Im not an email address!",
 });
 
 aBadUser.save(function(err, result) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,8 @@ internals.root = (mongoose, options, subdocumentOptions) => {
   };
 };
 
-internals.convert = joiObject => {
+internals.convert = (joiObject, options = {}) => {
+  const typeKey = options.typeKey || "type";
   if (joiObject === undefined) {
     throw new Error("Ensure the value you're trying to convert exists!");
   }
@@ -48,7 +49,7 @@ internals.convert = joiObject => {
         for (const [key, value] of Object.entries(meta._mongoose)) {
           // Check for _objectId
           if (key === "type" && value === "ObjectId") {
-            output.type = internals.mongoose.Schema.Types.ObjectId;
+            output[typeKey] = internals.mongoose.Schema.Types.ObjectId;
 
             const originalJoiObject = Hoek.clone(joiObject);
 
@@ -77,7 +78,7 @@ internals.convert = joiObject => {
   if (joiObject.type === "object") {
     //  Allow for empty object - https://github.com/hapijs/joi/blob/v9.0.0-3/API.md#object
     if (!joiObject.$_terms.keys)
-      return { type: internals.mongoose.Schema.Types.Mixed };
+      return { [typeKey]: internals.mongoose.Schema.Types.Mixed };
 
     joiObject.$_terms.keys.forEach(child => {
       output[child.key] = internals.convert(child.schema);
@@ -105,15 +106,15 @@ internals.convert = joiObject => {
     output.required = true;
   }
 
-  if (output.type) {
+  if (output[typeKey]) {
     return output;
   }
 
-  output.type = internals.typeDeterminer(joiObject);
+  output[typeKey] = internals.typeDeterminer(joiObject);
 
   // If this is an array, let's get rid of the validation cos it causes major
   // beef with validation
-  if (Array.isArray(output.type)) {
+  if (Array.isArray(output[typeKey])) {
     delete output.validate;
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -1026,3 +1026,18 @@ describe("Joigoose integration tests", () => {
     });
   });
 });
+
+describe("Joigoose custom conversion options", () => {
+  let Joigoose;
+
+  before(() => {
+    Joigoose = require("../lib")(Mongoose);
+  });
+
+  it("should use custom typeKey in conversion", () => {
+    const output = Joigoose.convert(S(), { typeKey: "$type" });
+    expect(output.$type).to.equal(String);
+    expect(output.type).to.equal(undefined);
+    expect(output.validate).to.exist();
+  });
+});


### PR DESCRIPTION
We need to use mongoose with a custom typeKey. This means the key reserved for specifying type will be something else than "type" (for instance "$type" or "__type").

This clashes with the usage of joigoose, since if mongoose is configured that way, it will complain about the "type" key since it is looking for the "$type" key (or whatever you chose).

This PR adds the possibility to pass along an options object to the convert method where more similar needs could be added in the future. Right now it accepts a "typeKey" (same as the mongoose option name) and uses that string as typeKey (default is still "type").

I'm not sure if you'd rather like that option to be placed among the global ones instead of locally on the convert method, feel free to change it to suit your strategy, or ask me to change it.

I think this is a very useful package. :)