### PR TITLE
fix: typeKey working as intended with nested types

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -174,18 +174,19 @@ internals.typeDeterminer = (joiObject, options = {}) => {
 
     // Collate all meta objects because these need to be pushed into the schema options
     let schemaOptions = joiObject.$_terms.metas.reduce(
-      (opts, currentOption) =>
-        Object.assign({}, opts._mongoose, currentOption._mongoose),
+      (opts, currentOption) => ({
+        ...opts._mongoose,
+        ...currentOption._mongoose
+      }),
       {}
     );
 
     // Combine the explicit schema options with the global subdocument options
     if (internals.subdocumentOptions) {
-      schemaOptions = Object.assign(
-        {},
-        internals.subdocumentOptions,
-        schemaOptions
-      );
+      schemaOptions = {
+        ...internals.subdocumentOptions,
+        ...schemaOptions
+      };
     }
 
     if (

--- a/lib/index.js
+++ b/lib/index.js
@@ -81,7 +81,7 @@ internals.convert = (joiObject, options = {}) => {
       return { [typeKey]: internals.mongoose.Schema.Types.Mixed };
 
     joiObject.$_terms.keys.forEach(child => {
-      output[child.key] = internals.convert(child.schema);
+      output[child.key] = internals.convert(child.schema, options);
 
       if (internals.isObjectId(child.schema)) {
         child.schema._isObjectId = true;
@@ -110,7 +110,7 @@ internals.convert = (joiObject, options = {}) => {
     return output;
   }
 
-  output[typeKey] = internals.typeDeterminer(joiObject);
+  output[typeKey] = internals.typeDeterminer(joiObject, options);
 
   // If this is an array, let's get rid of the validation cos it causes major
   // beef with validation
@@ -121,7 +121,7 @@ internals.convert = (joiObject, options = {}) => {
   return output;
 };
 
-internals.typeDeterminer = joiObject => {
+internals.typeDeterminer = (joiObject, options = {}) => {
   if (joiObject.type === "string") {
     // If the type has already been set, that's probably
     // because it was an ObjectId. In this case, don't set the
@@ -174,8 +174,8 @@ internals.typeDeterminer = joiObject => {
 
     // Collate all meta objects because these need to be pushed into the schema options
     let schemaOptions = joiObject.$_terms.metas.reduce(
-      (options, currentOption) =>
-        Object.assign({}, options._mongoose, currentOption._mongoose),
+      (opts, currentOption) =>
+        Object.assign({}, opts._mongoose, currentOption._mongoose),
       {}
     );
 
@@ -188,12 +188,14 @@ internals.typeDeterminer = joiObject => {
       );
     }
 
-    if (internals.typeDeterminer(joiObject.$_terms.items[0]) !== Object) {
-      type.push(internals.convert(joiObject.$_terms.items[0]));
+    if (
+      internals.typeDeterminer(joiObject.$_terms.items[0], options) !== Object
+    ) {
+      type.push(internals.convert(joiObject.$_terms.items[0], options));
     } else {
       type.push(
         new internals.mongoose.Schema(
-          internals.convert(joiObject.$_terms.items[0]),
+          internals.convert(joiObject.$_terms.items[0], options),
           schemaOptions
         )
       );

--- a/test/index.js
+++ b/test/index.js
@@ -1035,9 +1035,64 @@ describe("Joigoose custom conversion options", () => {
   });
 
   it("should use custom typeKey in conversion", () => {
-    const output = Joigoose.convert(S(), { typeKey: "$type" });
-    expect(output.$type).to.equal(String);
-    expect(output.type).to.equal(undefined);
-    expect(output.validate).to.exist();
+    const testJoiSchema = O().keys({
+      testString: S(),
+      testNumber: N(),
+      testDate: D(),
+      testBoolean: B(),
+      testObject: O().keys({
+        nestedTestString: S(),
+        nestedTestNumber: N(),
+        nestedTestDate: D(),
+        nestedTestBoolean: B()
+      }),
+      testStringArray: A().items(S()),
+      testNumberArray: A().items(N()),
+      testDateArray: A().items(D()),
+      testBooleanArray: A().items(B())
+    });
+    const output = Joigoose.convert(testJoiSchema, { typeKey: "$type" });
+
+    // Custom typeKey exists and specifies the correct type
+    expect(output.testString.$type).to.equal(String);
+    expect(output.testNumber.$type).to.equal(Number);
+    expect(output.testDate.$type).to.equal(Date);
+    expect(output.testBoolean.$type).to.equal(Boolean);
+    expect(output.testObject.nestedTestString.$type).to.equal(String);
+    expect(output.testObject.nestedTestNumber.$type).to.equal(Number);
+    expect(output.testObject.nestedTestDate.$type).to.equal(Date);
+    expect(output.testObject.nestedTestBoolean.$type).to.equal(Boolean);
+    expect(output.testStringArray.$type[0].$type).to.equal(String);
+    expect(output.testNumberArray.$type[0].$type).to.equal(Number);
+    expect(output.testDateArray.$type[0].$type).to.equal(Date);
+    expect(output.testBooleanArray.$type[0].$type).to.equal(Boolean);
+
+    // Default typeKey does not exist
+    expect(output.testString.type).to.not.exist();
+    expect(output.testNumber.type).to.not.exist();
+    expect(output.testDate.type).to.not.exist();
+    expect(output.testBoolean.type).to.not.exist();
+    expect(output.testObject.nestedTestString.type).to.not.exist();
+    expect(output.testObject.nestedTestNumber.type).to.not.exist();
+    expect(output.testObject.nestedTestDate.type).to.not.exist();
+    expect(output.testObject.nestedTestBoolean.type).to.not.exist();
+    expect(output.testStringArray.$type[0].type).to.not.exist();
+    expect(output.testNumberArray.$type[0].type).to.not.exist();
+    expect(output.testDateArray.$type[0].type).to.not.exist();
+    expect(output.testBooleanArray.$type[0].type).to.not.exist();
+
+    // .validate() should exist
+    expect(output.testString.validate).to.exist();
+    expect(output.testNumber.validate).to.exist();
+    expect(output.testDate.validate).to.exist();
+    expect(output.testBoolean.validate).to.exist();
+    expect(output.testObject.nestedTestString.validate).to.exist();
+    expect(output.testObject.nestedTestNumber.validate).to.exist();
+    expect(output.testObject.nestedTestDate.validate).to.exist();
+    expect(output.testObject.nestedTestBoolean.validate).to.exist();
+    expect(output.testStringArray.$type[0].validate).to.exist();
+    expect(output.testNumberArray.$type[0].validate).to.exist();
+    expect(output.testDateArray.$type[0].validate).to.exist();
+    expect(output.testBooleanArray.$type[0].validate).to.exist();
   });
 });


### PR DESCRIPTION
It seems I was a bit optimistic on the convert recursion. It is called from other places as well. I made the test considerably more covering and created a fix so the typeKey is propagated into nested types.

To do this I had to pass the options object into the typeDeterminer as well. What do you think?